### PR TITLE
Modify the URL filter to not mark URLs bad only because of errors

### DIFF
--- a/url_filter/README.txt
+++ b/url_filter/README.txt
@@ -7,8 +7,7 @@ The filter checks a number of matchers against the lowercased version of an inpu
 If all items from a single line in the matchers array are contained within the URL it is deemed as not good for usage.
 For task1 the matchers array is MATCHERS_ALL, for task2 - MATCHERS_SIMPLE.
 
-In order to handle shortened URLs, the filtering functions attempt to expand all URLs to their full form (needs active internet connectivity) and then follow the same matching procedure as above using the extended form.
-An error in the URL expansion process will mark the input URL as not good.
+In order to handle shortened URLs, the filtering functions attempt to expand all URLs to their full form (needs active internet connectivity) and then follow the same matching procedure as above using the expanded form.
 
 The python file contains some examples, simply run it with "python url_filter.py" and observe the output.
 

--- a/url_filter/url_filter.py
+++ b/url_filter/url_filter.py
@@ -106,22 +106,23 @@ def _expand_url(url):
 	return response.geturl()
 
 def _check_matchers(urlString, allMatchers = True):
-	if not isinstance(urlString, str):
-		print('Error, the provided parameter is not a string. Will be marked as BAD.')
-		return True
 	urlLower = urlString.lower()
 	matchers = MATCHERS_ALL if allMatchers else MATCHERS_SIMPLE
 	return any([all([item in urlLower for item in row]) for row in matchers])
 
 def _is_url_bad(urlString, allMatchers = True):
+	if not isinstance(urlString, str):
+		print('Error, the provided parameter is not a string. Cannot determine if it is BAD.')
+		return False
+
 	if _check_matchers(urlString, allMatchers):
 		return True
 	try:
 		urlExpanded = _expand_url(urlString)
 	except:
 		print('Error while expanding URL "' + urlString + '":', str(sys.exc_info()[1]))
-		print('Will be marked as BAD')
-		return True
+		print('Cannot currently determine if the URL is BAD, examine manually.')
+		return False
 	return _check_matchers(urlExpanded, allMatchers)
 
 def is_url_bad_task1(urlString):
@@ -143,10 +144,7 @@ EXAMPLES = [
 	# OK for both tasks:
 	'https://www.washingtonpost.com/news/tripping/wp/2017/11/30/car-rental-companies-find-a-way-to-ding-motorists-for-electronic-tolling/',
 	'https://en.wikipedia.org/wiki/Donald_Trump',
-	'http://goo.gl/eRJPti',
-	# BAD for technical reasons:
-	1616,
-	'http://www.not-a-real-site-and-so-cannot-be-expanded.com'
+	'http://goo.gl/eRJPti'
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Previously the URL filter pessimistically marked a given URL as bad if there were some errors during the process of checking it (mainly in the URL expansion)
  - This was well documented (and examples were provided) but it may not have been the most expected way to handle these cases
- Now changing the URL filter to only report the occurring errors but not explicitly mark the input URL as bad
   - Also reported is the fact that no certain conclusion can be drawn whether the given URL is bad or not. This means that the responsibility of using the URL lies on the party using it.